### PR TITLE
Chore: Use ssh private key to push version bumps

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Set up SSH agent
         if: steps.bump.outputs.newTag != ''
-        uses: webfactory/ssh-agent@v0.8.0
+        uses: webfactory/ssh-agent@v0.9.1
         with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -118,5 +118,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:${{ github.repository }}.git
-          git push
+          git push origin main
           git push origin ${{ steps.bump.outputs.newTag }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -104,7 +104,7 @@ jobs:
         if: steps.bump.outputs.newTag != ''
         uses: webfactory/ssh-agent@v0.9.1
         with:
-          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+          ssh-private-key: ${{ secrets.COMMIT_KEY }}
 
       # The git push command, now authenticated with the SSH key
       - name: Push new version and tag

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -85,6 +85,7 @@ jobs:
         run: cat ./package.json
 
       - name: "Automated Version Bump"
+        id: bump
         uses: "phips28/gh-action-bump-version@master"
         with:
           minor-wording: "solaceminor,SolaceMinor,SOLACEMINOR"
@@ -92,8 +93,30 @@ jobs:
           patch-wording: "solacepatch,SolacePatch,SOLACEPATCH"
           tag-prefix: ""
           commit-message: "CI: bumps version to {{version}} [skip ci]" # Add skip ci tag
+          skip-push: "true"
         env:
           #Required for version bumping and by-passing branch protection
-          GITHUB_TOKEN: ${{ secrets.COMMIT_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "cat package.json"
         run: cat ./package.json
+
+      - name: Set up SSH agent
+        if: steps.bump.outputs.newTag != ''
+        uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+
+      # The git push command, now authenticated with the SSH key
+      - name: Push new version and tag
+        if: steps.bump.outputs.newTag != ''
+        run: |
+          # The `phips28` action will have already committed the changes.
+          # We just need to push them to the remote.
+          # NOTE: The email "41898282+github-actions[bot]@users.noreply.github.com" is required
+          # so that GitHub recognizes the commit as made by the GitHub Actions bot,
+          # which helps with permissions and attribution.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin git@github.com:${{ github.repository }}.git
+          git push
+          git push origin ${{ steps.bump.outputs.newTag }}


### PR DESCRIPTION
- Use github token to generate version bump
- Use SSH key to be able to push those version bump to remote