### PR TITLE
fix(DATAGO-107901): Fix npm publish by using Github App Secrets

### DIFF
--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -7,12 +7,6 @@ on:
 permissions:
   contents: write
   packages: write
-  id-token: write
-  pull-requests: write
-  actions: read
-  statuses: write
-  checks: write
-  repository-projects: read
 
 jobs:
   build:
@@ -20,20 +14,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      # Setup .npmrc file to publish to GitHub Packages
       - uses: actions/setup-node@v3
         with:
           node-version: 20
           cache: "npm"
           registry-url: https://npm.pkg.github.com/
-          # Defaults to the user or organization that owns the workflow file
           scope: "@SolaceDev"
+      # Generate GitHub App installation token using official action
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ steps.generate_token.outputs.token }}" > .npmrc
           echo "@SolaceDev:registry=https://npm.pkg.github.com/" >> .npmrc
           echo "legacy-peer-deps=true" >> .npmrc
           npm ci
           npm publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
NPM ci publish fails due to the repo in public mode while the registry is private.
The registry is still preferred to be kept private. We will use github app secrets to generate a PAT to be able to publish