### PR TITLE
Use same GitHub token for publish

### DIFF
--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -28,19 +28,12 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          
+
       # Use GITHUB_TOKEN for install
-      - name: Configure npm for install
+      - name: Configure npm for install and publish
         run: |
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > .npmrc
           echo "@SolaceDev:registry=https://npm.pkg.github.com/" >> .npmrc
           echo "legacy-peer-deps=true" >> .npmrc
       - run: npm ci
-      
-      # Use GitHub App token for publish
-      - name: Configure npm for publish
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ steps.generate_token.outputs.token }}" > .npmrc
-          echo "@SolaceDev:registry=https://npm.pkg.github.com/" >> .npmrc
-          echo "legacy-peer-deps=true" >> .npmrc
       - run: npm publish

--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -20,15 +20,6 @@ jobs:
           cache: "npm"
           registry-url: https://npm.pkg.github.com/
           scope: "@SolaceDev"
-      # Generate GitHub App installation token using official action
-      - name: Generate GitHub App Token
-        id: generate_token
-
-        uses: actions/create-github-app-token@v1.10.4
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       # Use GITHUB_TOKEN for install
       - name: Configure npm for install and publish
         run: |


### PR DESCRIPTION
After reviewing the permissions where the repository is public but the package registry is private, the preferred route is to manually whitelist the repository in the package settings to have `write` access. 